### PR TITLE
Remove incorrect font-family

### DIFF
--- a/src/sass/_gdpr-cookie-notice.scss
+++ b/src/sass/_gdpr-cookie-notice.scss
@@ -115,7 +115,6 @@ $icon_caret: 'data:image/svg+xml;utf8,<svg height="12" viewBox="0 0 8 12" width=
     }
 
     &-title {
-      font-family: SanFranciscoText-Semibold;
       font-size: 18px;
       color: $modal_title;
       font-weight: 600;


### PR DESCRIPTION
The `.gdpr-cookie-notice-modal-title` heading is getting a serif font on Chrome + macOS Catalina (10.15.6) (and probably also other platforms):

<img width="581" alt="Screen Shot 2020-07-30 at 15 18 01" src="https://user-images.githubusercontent.com/1935696/88927657-07621b80-d278-11ea-8aeb-e262153cfad8.png">

Disabling this causes fallback to the `-apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu` font, which looks correct:

<img width="563" alt="Screen Shot 2020-07-30 at 15 21 20" src="https://user-images.githubusercontent.com/1935696/88927898-69bb1c00-d278-11ea-8923-4e1e11f441f1.png">
